### PR TITLE
Remove reference to unnecessary tdp.js file

### DIFF
--- a/crtool/jinja2/crtool/crt-base.html
+++ b/crtool/jinja2/crtool/crt-base.html
@@ -73,7 +73,6 @@
 {# Conditional comment used to block IE8 and under from receiving JS #}
 <!--[if gt IE 8]><!-->
     {# Include site-wide JavaScript. #}
-    <script src="{{ static('tdp/js/tdp.js') }}"></script>
     <script src="{{ static('tdp/js/crtool.react.v1.js') }}"></script>
 <!--<![endif]-->
 


### PR DESCRIPTION
This file is not needed in the CR Tool, and it in fact does not exist anymore, which was causing a 500 when Django could not find it.

## Removals

- Eliminates unnecessary inclusion of the (now-defunct) `tdp.js` file in `crt-base.html`

## Todos

- In a future PR, we should clean up all other references in this PR to the string `tdp`, which is muddying the waters when this repo no longer has a code-based connection to the other TDP stuff.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
