### PR TITLE
Remove unnecessary django-js-asset dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "Django>=2.2,<2.3",
-    "django-js-asset==1.1.0",
 ]
 
 
@@ -20,7 +19,7 @@ testing_extras = [
 
 setup(
     name="crtool",
-    url="https://github.com/cfpb/teachers-digital-platform",
+    url="https://github.com/cfpb/curriculum-review-tool",
     author="CFPB",
     author_email="tech@cfpb.gov",
     description="Teachers Curriculum Review tool",


### PR DESCRIPTION
It doesn't look like this repository needs the [django-js-asset](https://pypi.org/project/django-js-asset/) dependency any longer, if it ever did.

While I'm in here I'm correcting the setup.py URL to the renamed one.

## How to test this PR

[Grep the code for any use of `js_asset`.](https://github.com/cfpb/curriculum-review-tool/search?q=js_asset&unscoped_q=js_asset)

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)