### PR TITLE
Add tests for crtoolLocalStorage.init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3381,6 +3381,25 @@
         "babel-types": "^6.24.1"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "autoprefixer": "8.6.5",
     "babel-jest": "24.9.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "cf-atomic-component": "8.0.1",

--- a/src/__tests__/app_test.js
+++ b/src/__tests__/app_test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import localStorage from 'mock-local-storage';
+import 'mock-local-storage';
 import renderer from 'react-test-renderer';
-import jest from 'jest';
 
 import crtoolLocalStorage from '../crtoolLocalStorage';
 import App from '../App';
 
-crtoolLocalStorage.initForTesting(localStorage);
+crtoolLocalStorage.isReady = () => true;
+crtoolLocalStorage.saveIfDirty = () => 1;
 
 it('renders without crashing', () => {
   const component = renderer.create(

--- a/src/__tests__/crtoolLocalStorage/init_test.js
+++ b/src/__tests__/crtoolLocalStorage/init_test.js
@@ -1,0 +1,170 @@
+import 'mock-local-storage';
+
+import C from "../../js/business.logic/constants";
+import ls, { CHECK_FREQUENCY } from '../../crtoolLocalStorage';
+
+const testToken = 'abcd';
+const consoleError = console.error;
+
+beforeEach(() => {
+  ls.locationSearch = '';
+  global.localStorage.clear();
+  ls.localStorage = global.localStorage;
+  ls.pushState = jest.fn();
+  ls.setHref = jest.fn();
+  ls.getHref = () => 'http://example.com/page';
+  console.error = jest.fn();
+});
+
+afterAll(() => {
+  console.error = consoleError;
+});
+
+it('init() with no token forwards to start', async () => {
+  await ls.init();
+
+  expect( ls.setHref.mock.calls[0][0] ).toBe( C.START_PAGE_RELATIVE_URL );
+});
+
+it('init() gets token from LS, but LS nor server has it', async () => {
+  ls.localStorage.setItem('curriculumReviewId', testToken);
+  ls.fetchReviewFromServer = async () => undefined;
+
+  await ls.init();
+
+  expect(console.error.mock.calls.length).toBe(0);
+  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
+  expect(ls.setHref.mock.calls[0][0]).toBe(C.START_PAGE_RELATIVE_URL);
+  expect(ls.localStorage.getItem('crtool.' + testToken)).toBe(null);
+  expect(ls.localStorage.getItem('curriculumReviewId')).toBe(null);
+});
+
+it('init() gets token from LS, but LS is invalid', async () => {
+  ls.localStorage.setItem('curriculumReviewId', testToken);
+  ls.localStorage.setItem('crtool.' + testToken, '{"foo":"invalid"}');
+  ls.fetchReviewFromServer = async () => undefined;
+
+  await ls.init();
+
+  expect(console.error.mock.calls[0][0].message).toBe('invalid review');
+  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
+  expect(ls.setHref.mock.calls[0][0]).toBe(C.START_PAGE_RELATIVE_URL);
+  expect(ls.localStorage.getItem('crtool.' + testToken)).toBe(null);
+  expect(ls.localStorage.getItem('curriculumReviewId')).toBe(null);
+});
+
+it('init() finds DB review, but LS has older', async () => {
+  const oldDate = new Date(new Date().getTime() - 1000e3);
+  ls.localStorage.setItem('curriculumReviewId', testToken);
+  ls.localStorage.setItem('crtool.' + testToken, JSON.stringify({
+    id: testToken,
+    last_updated: 'something',
+    ls_modified_time: oldDate.toISOString(),
+    value: 'local',
+  }));
+  const dbReview = {
+    id: testToken,
+    last_updated: 'something',
+    ls_modified_time: new Date().toISOString(),
+    value: 'db',
+  };
+  ls.fetchReviewFromServer = async () => dbReview;
+  ls.scheduleSaveIfDirty = jest.fn();
+
+  await ls.init();
+
+  expect(console.error.mock.calls.length).toBe(0);
+  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
+  expect(ls.setHref.mock.calls.length).toBe(0);
+  expect(ls.review).toMatchObject(dbReview);
+  expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"db"');
+  expect(ls.localStorage.getItem('curriculumReviewId')).toBe(testToken);
+  expect(ls.scheduleSaveIfDirty.mock.calls[0][0]).toBe(CHECK_FREQUENCY);
+});
+
+it('init() finds DB review and URL has token', async () => {
+  const oldDate = new Date(new Date().getTime() - 1000e3);
+  ls.locationSearch = '?token=' + testToken;
+  ls.localStorage.setItem('curriculumReviewId', testToken);
+  ls.localStorage.setItem('crtool.' + testToken, JSON.stringify({
+    id: testToken,
+    last_updated: 'something',
+    ls_modified_time: oldDate.toISOString(),
+    value: 'local',
+  }));
+  const dbReview = {
+    id: testToken,
+    last_updated: 'something',
+    ls_modified_time: new Date().toISOString(),
+    value: 'db',
+  };
+  ls.fetchReviewFromServer = async () => dbReview;
+  ls.scheduleSaveIfDirty = jest.fn();
+
+  await ls.init();
+
+  expect(console.error.mock.calls.length).toBe(0);
+  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setHref.mock.calls.length).toBe(0);
+  expect(ls.review).toMatchObject(dbReview);
+  expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"db"');
+  expect(ls.localStorage.getItem('curriculumReviewId')).toBe(testToken);
+  expect(ls.scheduleSaveIfDirty.mock.calls[0][0]).toBe(CHECK_FREQUENCY);
+});
+
+it('init() finds DB review and LS has newer', async () => {
+  const oldDate = new Date(new Date().getTime() - 1000e3);
+  ls.locationSearch = '?token=' + testToken;
+  ls.localStorage.setItem('curriculumReviewId', testToken);
+  const lsReview = {
+    id: testToken,
+    last_updated: 'something',
+    ls_modified_time: new Date().toISOString(),
+    value: 'local',
+  };
+  ls.localStorage.setItem('crtool.' + testToken, JSON.stringify(lsReview));
+  const dbReview = {
+    id: testToken,
+    last_updated: 'something',
+    ls_modified_time: oldDate.toISOString(),
+    value: 'db',
+  };
+  ls.fetchReviewFromServer = async () => dbReview;
+  ls.scheduleSaveIfDirty = jest.fn();
+
+  await ls.init();
+
+  expect(console.error.mock.calls.length).toBe(0);
+  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setHref.mock.calls.length).toBe(0);
+  expect(ls.review).toMatchObject(lsReview);
+  expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"local"');
+  expect(ls.localStorage.getItem('curriculumReviewId')).toBe(testToken);
+  expect(ls.scheduleSaveIfDirty.mock.calls[0][0]).toBe(0);
+});
+
+it('init() finds fresh review, sets local time', async () => {
+  const oldDate = new Date(new Date().getTime() - 1000e3);
+  ls.locationSearch = '?token=' + testToken;
+  ls.getISODate = () => oldDate.toISOString();
+  const dbReview = {
+    id: testToken,
+    last_updated: 'something',
+    value: 'db',
+  };
+  ls.fetchReviewFromServer = async () => dbReview;
+  ls.scheduleSaveIfDirty = jest.fn();
+
+  await ls.init();
+
+  expect(console.error.mock.calls.length).toBe(0);
+  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setHref.mock.calls.length).toBe(0);
+  expect(ls.review).toMatchObject({
+    ...dbReview,
+    ls_modified_time: oldDate.toISOString(),
+  });
+  expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"db"');
+  expect(ls.localStorage.getItem('curriculumReviewId')).toBe(testToken);
+  expect(ls.scheduleSaveIfDirty.mock.calls[0][0]).toBe(0);
+});

--- a/src/jest/setup.js
+++ b/src/jest/setup.js
@@ -1,4 +1,5 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import 'babel-polyfill';
 
 configure({ adapter: new Adapter() });


### PR DESCRIPTION

Add tests for crtoolLocalStorage.init and also fixe a couple corner cases found via tests!
Enables async tests

---

## Additions

- babel-polyfill
- unit tests for crtoolLocalStorage init()

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets