### PR TITLE
Support LTS + Current versions of Django

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 # Do not look up into parent directories.
 # Prevents ESLint version conflicts when cloned into
-# cfgov-refresh's develop-apps folder.
+# consumerfinance.gov's develop-apps folder.
 root: true
 
 # Environments.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Run back-end tests
         run: |
-          tox -e lint,py36-dj22,dj36-dj30
+          tox -e lint,py36-dj22,py36-dj30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Run back-end tests
         run: |
-          tox -e lint,py36-dj22
+          tox -e lint,py36-dj22,dj36-dj30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Run back-end tests
         run: |
-          tox -e lint,py36-dj22,py36-dj30
+          tox -e lint,py36-dj22,py36-dj31

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ htmlcov/
 nosetests.xml
 coverage.xml
 /coverage
-/cfgov-refresh/
 
 # Front-End #
 #############

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The content dimension has three different views based on the grade range (elemen
 ## Technology stack
 
 - The CR Tool is primarily a **React app**.
-- It is packaged up in the form of a basic **Django app** for ease of integration with the [cfgov-refresh](https://github.com/cfpb/cfgov-refresh) Django project.
+- It is packaged up in the form of a basic **Django app** for ease of integration with the [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov) Django project.
 - **Jinja2** [is used](crtool/jinja2/crtool/) for HTML templating.
 - [**create-react-app**](https://github.com/facebook/create-react-app) was used for initial setup
 - `localStorage` [is used](src/js/business.logic/repository.js) to save a user's progress across multiple sessions.
@@ -20,9 +20,9 @@ The content dimension has three different views based on the grade range (elemen
 
 ## Installation for development
 
-The CR Tool will only work fully in the context of cfgov-refresh.
+The CR Tool will only work fully in the context of consumerfinance.gov.
 
-1. Clone this repository and install it locally into your cfgov-refresh environment, following [the cfgov-refresh docs for working on satellite apps](https://cfpb.github.io/cfgov-refresh/related-projects/#developing-python-packages-with-cfgov-refresh).
+1. Clone this repository and install it locally into your consumerfinance.gov environment, following [the consumerfinance.gov docs for working on satellite apps](https://cfpb.github.io/consumerfinance.gov/related-projects/#developing-python-packages-with-consumerfinance.gov).
 1. In this repository's root, run `./setup.sh` to install front-end dependencies and do an initial build.
 1. Start your development server
 1. Go to http://localhost:8000/practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/
@@ -49,7 +49,7 @@ The application ultimately serves two Jinja templates at particular URLs:
 2. [`crt-survey.html`](crtool/jinja2/crtool/crt-survey.html)
 
    This template serves the React application for the review interface itself at the `tool` URL. It is nothing more than an empty `<div id="react">` that serves at the hook for the React app initialization.
-   This templates extends the [`crt-base.html`](crtool/jinja2/crtool/crt-base.html) template, which extends the `layout-full` template from cfgov-refresh, overrides a few things to enforce focusing on the tool, adds in the tool-specific CSS and JS.
+   This templates extends the [`crt-base.html`](crtool/jinja2/crtool/crt-base.html) template, which extends the `layout-full` template from consumerfinance.gov, overrides a few things to enforce focusing on the tool, adds in the tool-specific CSS and JS.
 
 ### JavaScript
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The content dimension has three different views based on the grade range (elemen
 
 The CR Tool will only work fully in the context of consumerfinance.gov.
 
-1. Clone this repository and install it locally into your consumerfinance.gov environment, following [the consumerfinance.gov docs for working on satellite apps](https://cfpb.github.io/consumerfinance.gov/related-projects/#developing-python-packages-with-consumerfinance.gov).
+1. Clone this repository and install it locally into your consumerfinance.gov environment, following [the consumerfinance.gov docs for working on satellite apps](https://cfpb.github.io/consumerfinance.gov/related-projects/#developing-python-packages-with-consumerfinancegov).
 1. In this repository's root, run `./setup.sh` to install front-end dependencies and do an initial build.
 1. Start your development server
 1. Go to http://localhost:8000/practitioner-resources/youth-financial-education/curriculum-review/before-you-begin/

--- a/crtool/css/crtool.less
+++ b/crtool/css/crtool.less
@@ -1,10 +1,10 @@
 /* ==========================================================================
-   Teachers Digital Platform
+   Curriculum Review Tool
    ========================================================================== */
 
 // Import Capital Framework by reference so that variables and mixins are
 // available, but the whole output doesn't duplicate what we're already getting
-// from cfgov-refresh.
+// from consumerfinance.gov.
 @import (reference) 'cf-core.less';
 @import (reference) 'cf-icons.less';
 @import (reference) 'cf-buttons.less';
@@ -18,7 +18,7 @@
 @import (reference) 'cf-tables.less';
 
 // TODO: Add (reference) back in for notifications/icons and remove temp/button-links.less once this PR is merged:
-// https://github.com/cfpb/cfgov-refresh/pull/3887/
+// https://github.com/cfpb/consumerfinance.gov/pull/3887/
 // @import 'temp/button-links.less';
 
 // Import any Capital Framework enhancements you might have

--- a/crtool/css/temp/button-links.less
+++ b/crtool/css/temp/button-links.less
@@ -1,6 +1,6 @@
 /* ==========================================================================
    TEMPORARY COPY OF BUTTON-LINKS
-   Remove when https://github.com/cfpb/cfgov-refresh/pull/3887 is
+   Remove when https://github.com/cfpb/consumerfinance.gov/pull/3887 is
    merged and deployed.
    ========================================================================== */
 

--- a/crtool/css/temp/cf-icons.less
+++ b/crtool/css/temp/cf-icons.less
@@ -1,6 +1,6 @@
 /* ==========================================================================
    TEMPORARY COPY OF CF-ICONS
-   Remove when https://github.com/cfpb/cfgov-refresh/pull/3887 is
+   Remove when https://github.com/cfpb/consumerfinance.gov/pull/3887 is
    merged and deployed.
    ========================================================================== */
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     },
     classifiers=[
         "Framework :: Django",
+        "Framework :: Django :: 2",
         "Framework :: Django :: 3",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 2",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "Django>=2.2,<2.3",
+    "Django>=2.2,<3.1",
     "django-js-asset==1.1.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "Django>=2.2,<3.1",
+    "Django>=2.2,<3.2",
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 # Run these envs when tox is invoked without -e
-envlist=lint,py{36,38}-dj{22,30}
+envlist=lint,py{36,38}-dj{22,31}
 
 [testenv]
 basepython=
@@ -10,7 +10,7 @@ basepython=
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 deps=
     dj22: Django>=2.2,<2.3
-    dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
  
 setenv=
      DJANGO_SETTINGS_MODULE=crtool.tests.settings
@@ -43,7 +43,6 @@ exclude=
     __pycache__,
     gulp,
     node_modules,
-    ./cfgov-refresh,
     */migrations/*.py,
     .eggs/*,
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 skipsdist=True
 # Run these envs when tox is invoked without -e
-envlist=lint,py{36,38}-dj{22}
+envlist=lint,py{36,38}-dj{22,30}
 
 [testenv]
 basepython=
@@ -10,6 +10,8 @@ basepython=
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 deps=
     dj22: Django>=2.2,<2.3
+    dj30: Django>=3.0,<3.1
+ 
 setenv=
      DJANGO_SETTINGS_MODULE=crtool.tests.settings
      PYTHONPATH={toxinidir}/crtool:{env:PYTHONPATH:}


### PR DESCRIPTION
This change updates our supported version range to the LTS release of Django (2.2) and the current release of Django (3.1).

## Additions

- Added support for Django 3.1

## Removals

- Removed support for Django 1.11