### PR TITLE
store curriculumId in a url hash instead of a querystring

### DIFF
--- a/crtool/jinja2/crtool/crt-start.html
+++ b/crtool/jinja2/crtool/crt-start.html
@@ -235,12 +235,12 @@
         <div class="o-tabs_tab o-tabs_tab__continue-review">
             <h2>Continue a review</h2>
             <p>Enter your access code to return to a review in progress.</p>
-            <form id="form__continue-review" class="o-form" method="GET" action="../tool">
+            <form id="form__continue-review" class="o-form" method="POST" action="../continue-review/">
                 <div class="o-form_group">
                     <div class="m-form-field m-form-field__select">
                     <label class="a-label a-label__heading" for="token--continue">Access code</label>
                     <div class="a-select">
-                        <select id="token--continue" name="token" value="">
+                        <select id="token--continue" name="access_code" value="">
                             <option value="">Enter your access code</option>
                         </select>
                         </div>
@@ -266,7 +266,7 @@
                     </div>
                 </div>
                 <div class="m-btn-group m-btn-group__wide">
-                    <button id="continue-review" class="a-btn button-push-analytics" type="submit" formaction="../tool">
+                    <button id="continue-review" class="a-btn button-push-analytics" type="submit">
                             Continue review
                     </button>
                 </div>

--- a/crtool/js/startPage.js
+++ b/crtool/js/startPage.js
@@ -61,10 +61,9 @@ function setBeginReviewButtonEnabling() {
   document.getElementById( 'tdp-crt-begin-review-btn' ).disabled = !isEnabled;
 
   // only enable continue button if token is set
-  const curiculumIdValue = document.getElementById( 'token--continue' ).value;
+  const curriculumIdValue = document.getElementById( 'token--continue' ).value;
 
-  document.getElementById( 'continue-review' ).disabled = curiculumIdValue ? false : true;
-
+  document.getElementById( 'continue-review' ).disabled = !curriculumIdValue;
 }
 
 /**
@@ -167,9 +166,9 @@ function saveWorkOutsideClickListener( event ) {
 }
 
 /**
- * Get available tokens from localStorage.
+ * Get available reviews from localStorage.
  *
- * @returns {Array} - List of available tokens
+ * @returns {Array} - List of available reviews
  */
 function getAvailableTokens() {
   const tokens = {};
@@ -279,7 +278,7 @@ function beginReviewButtonClick( event ) {
       const review = JSON.parse( this.responseText );
       localStorage.setItem( 'curriculumReviewId', review.id );
       localStorage.setItem( 'crtool.' + review.id, JSON.stringify( review ) );
-      window.location.href = '../tool?token=' + review.id;
+      location.href = '../tool/#id=' + review.id;
     }
   };
   const requestUrl = '../create-review/';
@@ -317,17 +316,16 @@ function clearLocalStorage( event ) {
  * Bind events.
  */
 function bindEvents() {
-  $( '#modal-save-work .save-work-push-analytics' ).click( function() { closeSaveWorkModalWindow(); } );
-  $( '#modal-start-over .start-over-close-push-analytics' ).click( function() { closeNewReviewModalWindow(); } );
-  $( '#modal-start-over .start-over-push-analytics' ).click( function( event ) { clearLocalStorage( event ); } );
-  $( 'form#begin-review-form .link-push-analytics' ).click( function( event ) { openSaveWorkModalWindow( event ); } );
-  $( 'form#form__continue-review .link-push-analytics' ).click( function( event ) { openSaveWorkModalWindow( event ); } );
-  $( 'form#begin-review-form' ).submit( function( event ) { beginReviewButtonClick( event ); } );
-  $( 'form#begin-review-form #new-review-modal-dialog-btn' ).click( function( event ) { openNewReviewModalWindow( event ); } );
-  $( 'form#begin-review-form #tdp-crt_title' ).change( function() { onValuesChanged(); } );
-  $( 'form#begin-review-form #tdp-crt_grade' ).change( function() { onValuesChanged(); } );
-  $( 'form#form__continue-review #token--continue' ).change( function() { onValuesChanged(); } );
-
+  $( '#modal-save-work .save-work-push-analytics' ).click( closeSaveWorkModalWindow );
+  $( '#modal-start-over .start-over-close-push-analytics' ).click( closeNewReviewModalWindow );
+  $( '#modal-start-over .start-over-push-analytics' ).click( clearLocalStorage );
+  $( 'form#begin-review-form .link-push-analytics' ).click( openSaveWorkModalWindow );
+  $( 'form#form__continue-review .link-push-analytics' ).click( openSaveWorkModalWindow );
+  $( 'form#begin-review-form' ).submit( beginReviewButtonClick );
+  $( 'form#begin-review-form #new-review-modal-dialog-btn' ).click( openNewReviewModalWindow );
+  $( 'form#begin-review-form #tdp-crt_title' ).change( onValuesChanged );
+  $( 'form#begin-review-form #tdp-crt_grade' ).change( onValuesChanged );
+  $( 'form#form__continue-review #token--continue' ).change( onValuesChanged );
 }
 
 /**

--- a/crtool/tests/test_views.py
+++ b/crtool/tests/test_views.py
@@ -8,7 +8,7 @@ from crtool.views import (
     continue_review,
     create_review,
     get_review,
-    update_review
+    update_review,
 )
 
 

--- a/crtool/urls.py
+++ b/crtool/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
         name='get_review'
     ),
     re_path(
+        r'^continue-review/$',
+        views.continue_review,
+        name='continue_review'
+    ),
+    re_path(
         r'^update-review/$',
         views.update_review,
         name='update_review'

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -18,7 +18,8 @@ def create_review(request):
         title = fd['tdp-crt_title'] if 'tdp-crt_title' in fd else ''
         pub_date = fd['tdp-crt_pubdate'] if 'tdp-crt_pubdate' in fd else ''
         grade_range = fd['tdp-crt_grade'] if 'tdp-crt_grade' in fd else ''
-        pass_code = fd['tdp-crt_pass_code'] if 'tdp-crt_pass_code' in fd else ''
+        pass_code = fd['tdp-crt_pass_code'] \
+            if 'tdp-crt_pass_code' in fd else ''
         review_id = CurriculumReviewSession.id_generator()
         last_updated = timezone.now()
 

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -1,8 +1,9 @@
 import json
+import time
 from datetime import datetime
 
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 
@@ -17,7 +18,7 @@ def create_review(request):
         title = fd['tdp-crt_title'] if 'tdp-crt_title' in fd else ''
         pub_date = fd['tdp-crt_pubdate'] if 'tdp-crt_pubdate' in fd else ''
         grade_range = fd['tdp-crt_grade'] if 'tdp-crt_grade' in fd else ''
-        passcode = fd['tdp-crt_pass_code'] if 'tdp-crt_pass_code' in fd else ''
+        pass_code = fd['tdp-crt_pass_code'] if 'tdp-crt_pass_code' in fd else ''
         review_id = CurriculumReviewSession.id_generator()
         last_updated = timezone.now()
 
@@ -25,7 +26,7 @@ def create_review(request):
             return HttpResponse(status=400)
         data = {
             'id': str(review_id),
-            'pass_code': passcode,
+            'pass_code': pass_code,
             'last_updated': str(datetime.isoformat(last_updated)),
             'curriculumTitle': title,
             'publicationDate': pub_date,
@@ -34,7 +35,7 @@ def create_review(request):
 
         review = CurriculumReviewSession.objects.create(
             id=review_id,
-            pass_code=passcode,
+            pass_code=pass_code,
             last_updated=last_updated,
             data=data
         )
@@ -42,14 +43,14 @@ def create_review(request):
         if review:
             return JsonResponse(review.data)
 
-    else:
-        return HttpResponse(status=400)
+    return HttpResponse(status=400)
 
 
+@csrf_exempt
 def get_review(request):
     data = {}
-    if request.method == 'GET':
-        review_id = request.GET.get('token')
+    if request.method == 'POST':
+        review_id = request.POST.get('token')
         try:
             review = CurriculumReviewSession.objects.get(id=review_id)
             if review:
@@ -60,7 +61,27 @@ def get_review(request):
             ValidationError
         ):
             return HttpResponse(status=404)
-    return JsonResponse(data)
+        return JsonResponse(data)
+    return HttpResponse(status=404)
+
+
+@csrf_exempt
+def continue_review(request):
+    if request.method == 'POST':
+        review_id = request.POST.get('access_code')
+        # Critical pause to prevent brute-forcing the shorter pass_code values
+        time.sleep(1)
+        try:
+            review = CurriculumReviewSession.objects.get(id=review_id)
+            if review:
+                return HttpResponseRedirect('../tool/#id=' + review.id)
+        except (
+            CurriculumReviewSession.DoesNotExist,
+            ValueError,
+            ValidationError
+        ):
+            return HttpResponse(status=404)
+    return HttpResponse(status=404)
 
 
 @csrf_exempt

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "Django>=2.2,<3.2",
-    "psycopg2==2.7.3.2"
+    "psycopg2>=2.8.4"
 ]
 
 

--- a/src/__tests__/crtoolLocalStorage/init_test.js
+++ b/src/__tests__/crtoolLocalStorage/init_test.js
@@ -7,10 +7,10 @@ const testToken = 'abcd';
 const consoleError = console.error;
 
 beforeEach(() => {
-  ls.locationSearch = '';
   global.localStorage.clear();
   ls.localStorage = global.localStorage;
-  ls.pushState = jest.fn();
+  ls.getLocationHash = jest.fn();
+  ls.setLocationHash = jest.fn();
   ls.setHref = jest.fn();
   ls.getHref = () => 'http://example.com/page';
   console.error = jest.fn();
@@ -33,7 +33,6 @@ it('init() gets token from LS, but LS nor server has it', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
   expect(ls.setHref.mock.calls[0][0]).toBe(C.START_PAGE_RELATIVE_URL);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toBe(null);
   expect(ls.localStorage.getItem('curriculumReviewId')).toBe(null);
@@ -47,7 +46,6 @@ it('init() gets token from LS, but LS is invalid', async () => {
   await ls.init();
 
   expect(console.error.mock.calls[0][0].message).toBe('invalid review');
-  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
   expect(ls.setHref.mock.calls[0][0]).toBe(C.START_PAGE_RELATIVE_URL);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toBe(null);
   expect(ls.localStorage.getItem('curriculumReviewId')).toBe(null);
@@ -74,7 +72,7 @@ it('init() finds DB review, but LS has older', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
+  expect(ls.setLocationHash.mock.calls[0][0]).toBe('#id=' + testToken);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject(dbReview);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"db"');
@@ -84,7 +82,7 @@ it('init() finds DB review, but LS has older', async () => {
 
 it('init() finds DB review and URL has token', async () => {
   const oldDate = new Date(new Date().getTime() - 1000e3);
-  ls.locationSearch = '?token=' + testToken;
+  ls.getLocationHash = () => '#id=' + testToken;
   ls.localStorage.setItem('curriculumReviewId', testToken);
   ls.localStorage.setItem('crtool.' + testToken, JSON.stringify({
     id: testToken,
@@ -104,7 +102,7 @@ it('init() finds DB review and URL has token', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setLocationHash.mock.calls.length).toBe(0);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject(dbReview);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"db"');
@@ -114,7 +112,7 @@ it('init() finds DB review and URL has token', async () => {
 
 it('init() finds DB review and LS has newer', async () => {
   const oldDate = new Date(new Date().getTime() - 1000e3);
-  ls.locationSearch = '?token=' + testToken;
+  ls.getLocationHash = () => '#id=' + testToken;
   ls.localStorage.setItem('curriculumReviewId', testToken);
   const lsReview = {
     id: testToken,
@@ -135,7 +133,7 @@ it('init() finds DB review and LS has newer', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setLocationHash.mock.calls.length).toBe(0);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject(lsReview);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"local"');
@@ -145,7 +143,7 @@ it('init() finds DB review and LS has newer', async () => {
 
 it('init() finds fresh review, sets local time', async () => {
   const oldDate = new Date(new Date().getTime() - 1000e3);
-  ls.locationSearch = '?token=' + testToken;
+  ls.getLocationHash = () => '#id=' + testToken;
   ls.getISODate = () => oldDate.toISOString();
   const dbReview = {
     id: testToken,
@@ -158,7 +156,7 @@ it('init() finds fresh review, sets local time', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setLocationHash.mock.calls.length).toBe(0);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject({
     ...dbReview,


### PR DESCRIPTION
Merging in some of Steve Clay's optimizations:

- Move id storage to URL hash instead of query string
- Make all forms use POST instead of GET
