### PR TITLE
Switch to the binary version of psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "Django>=2.2,<3.2",
-    "psycopg2>=2.8.4"
+    "psycopg2-binary==2.8.6"
 ]
 
 


### PR DESCRIPTION
We need to switch to the binary version of psycopg to resolve the following error:

```
[2020-09-28T20:58:23.289Z] #10 9.409 Collecting psycopg2>=2.8.4

[2020-09-28T20:58:23.289Z] #10 9.423   Downloading psycopg2-2.8.6.tar.gz (383 kB)

[2020-09-28T20:58:23.556Z] #10 9.845     ERROR: Command errored out with exit status 1:

[2020-09-28T20:58:23.556Z] #10 9.845      command: /opt/rh/rh-python36/root/usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-fcoovvjy/psycopg2/setup.py'"'"'; __file__='"'"'/tmp/pip-install-fcoovvjy/psycopg2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-pkv76heq

[2020-09-28T20:58:23.556Z] #10 9.845          cwd: /tmp/pip-install-fcoovvjy/psycopg2/

[2020-09-28T20:58:23.556Z] #10 9.845     Complete output (23 lines):

[2020-09-28T20:58:23.556Z] #10 9.845     running egg_info

[2020-09-28T20:58:23.556Z] #10 9.845     creating /tmp/pip-pip-egg-info-pkv76heq/psycopg2.egg-info

[2020-09-28T20:58:23.556Z] #10 9.845     writing /tmp/pip-pip-egg-info-pkv76heq/psycopg2.egg-info/PKG-INFO

[2020-09-28T20:58:23.556Z] #10 9.845     writing dependency_links to /tmp/pip-pip-egg-info-pkv76heq/psycopg2.egg-info/dependency_links.txt

[2020-09-28T20:58:23.556Z] #10 9.845     writing top-level names to /tmp/pip-pip-egg-info-pkv76heq/psycopg2.egg-info/top_level.txt

[2020-09-28T20:58:23.556Z] #10 9.845     writing manifest file '/tmp/pip-pip-egg-info-pkv76heq/psycopg2.egg-info/SOURCES.txt'

[2020-09-28T20:58:23.556Z] #10 9.845     

[2020-09-28T20:58:23.556Z] #10 9.845     Error: pg_config executable not found.

[2020-09-28T20:58:23.556Z] #10 9.845     

[2020-09-28T20:58:23.556Z] #10 9.845     pg_config is required to build psycopg2 from source.  Please add the directory

[2020-09-28T20:58:23.556Z] #10 9.845     containing pg_config to the $PATH or specify the full executable path with the

[2020-09-28T20:58:23.557Z] #10 9.845     option:

[2020-09-28T20:58:23.557Z] #10 9.845     

[2020-09-28T20:58:23.557Z] #10 9.845         python setup.py build_ext --pg-config /path/to/pg_config build ...

[2020-09-28T20:58:23.557Z] #10 9.845     

[2020-09-28T20:58:23.557Z] #10 9.845     or with the pg_config option in 'setup.cfg'.

[2020-09-28T20:58:23.557Z] #10 9.845     

[2020-09-28T20:58:23.557Z] #10 9.845     If you prefer to avoid building psycopg2 from source, please install the PyPI

[2020-09-28T20:58:23.557Z] #10 9.845     'psycopg2-binary' package instead.

[2020-09-28T20:58:23.557Z] #10 9.845     

[2020-09-28T20:58:23.557Z] #10 9.845     For further information please check the 'doc/src/install.rst' file (also at

[2020-09-28T20:58:23.557Z] #10 9.845     <https://www.psycopg.org/docs/install.html>).

[2020-09-28T20:58:23.557Z] #10 9.845     

[2020-09-28T20:58:23.557Z] #10 9.845     ----------------------------------------

[2020-09-28T20:58:23.817Z] #10 9.845 ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```