### PR TITLE
Remove CSRF middleware and csrf_exempt

### DIFF
--- a/crtool/tests/settings.py
+++ b/crtool/tests/settings.py
@@ -18,7 +18,6 @@ ROOT_URLCONF = "crtool.urls"
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -5,12 +5,10 @@ from datetime import datetime
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.utils import timezone
-from django.views.decorators.csrf import csrf_exempt
 
 from crtool.models import CurriculumReviewSession
 
 
-@csrf_exempt
 def create_review(request):
     if request.method == 'POST':
         fd = json.loads(request.body.decode("utf-8"))
@@ -47,7 +45,6 @@ def create_review(request):
     return HttpResponse(status=400)
 
 
-@csrf_exempt
 def get_review(request):
     data = {}
     if request.method == 'POST':
@@ -66,7 +63,6 @@ def get_review(request):
     return HttpResponse(status=404)
 
 
-@csrf_exempt
 def continue_review(request):
     if request.method == 'POST':
         review_id = request.POST.get('access_code')
@@ -85,7 +81,6 @@ def continue_review(request):
     return HttpResponse(status=404)
 
 
-@csrf_exempt
 def update_review(request):
     if request.method == 'POST':
         data = json.loads(request.body.decode("utf-8"))


### PR DESCRIPTION
We've removed CSRF from non-authenticated paths in cfpb/consumerfinance.gov#6366. The PR removes the CSRF middleware from the standalone testing settings and removes the `csrf_exempt` decorator from views, as it is no longer needed.