### PR TITLE
Limit review size and catch bad JSON

### DIFF
--- a/crtool/jinja2/crtool/crt-start.html
+++ b/crtool/jinja2/crtool/crt-start.html
@@ -162,6 +162,7 @@
                         <input class="a-text-input
                                     a-text-input__full"
                             type="text"
+                            maxlength="200"
                             id="tdp-crt_title"
                             name="tdp-crt_title">
                     </div>
@@ -181,6 +182,7 @@
                                             a-text-input__full"
                                         type="text"
                                         id="tdp-crt_pubdate"
+                                        maxlength="50"
                                         name="tdp-crt_pubdate">
                             </div>
                         </li>

--- a/crtool/js/startPage.js
+++ b/crtool/js/startPage.js
@@ -194,7 +194,7 @@ function setUpTokenDropdown() {
   const review = getCurrentReview();
 
   for ( const token in tokens ) {
-    if (tokens.hasOwnProperty( token )) {
+    if ( tokens.hasOwnProperty( token ) ) {
       const option = document.createElement( 'option' );
       option.text = tokens[token];
       option.value = token;

--- a/crtool/js/startPage.js
+++ b/crtool/js/startPage.js
@@ -194,13 +194,15 @@ function setUpTokenDropdown() {
   const review = getCurrentReview();
 
   for ( const token in tokens ) {
-    let markup;
-    if ( review && review.id === token ) {
-      markup = '<option value="' + token + '" selected="selected">' + tokens[token] + '</option>';
-    } else {
-      markup = '<option value="' + token + '">' + tokens[token] + '</option>';
+    if (tokens.hasOwnProperty( token )) {
+      const option = document.createElement( 'option' );
+      option.text = tokens[token];
+      option.value = token;
+      if ( review && review.id === token ) {
+        option.selected = true;
+      }
+      $( '#token--continue' ).append( option );
     }
-    $( '#token--continue' ).append( markup );
   }
   $( '#token--continue' ).select2( {
     tags: true,

--- a/crtool/tests/test_views.py
+++ b/crtool/tests/test_views.py
@@ -1,4 +1,3 @@
-# from django.test import TestCase
 import json
 
 from django.test import RequestFactory, TestCase

--- a/crtool/tests/test_views.py
+++ b/crtool/tests/test_views.py
@@ -1,7 +1,7 @@
 # from django.test import TestCase
 import json
 
-from django.test import Client, RequestFactory, TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from crtool.views import (
@@ -35,9 +35,9 @@ class CreateReviewTest(TestCase):
                 return False
         return True
 
-    def check_post(self, post, response_check, ajax=False, compare={}, content=None):
+    def check_post(self, post, response_check, ajax=False, compare={}, content=None):  # noqa 501
         if compare:
-            response_check(self.post(post, ajax=ajax), compare=compare, content=content)
+            response_check(self.post(post, ajax=ajax), compare=compare, content=content)  # noqa 501
         else:
             response_check(self.post(post, ajax=ajax), content=content)
 
@@ -46,7 +46,10 @@ class CreateReviewTest(TestCase):
             "HTTP_X_REQUESTED_WITH": "XMLHttpRequest",
             "content_type": "application/json",
         }
-        request = self.factory.post(reverse("create_review"), "invalid:json}", **kwargs)
+        request = self.factory.post(
+            reverse("create_review"),
+            "invalid:json}",
+            **kwargs)
         self.assertBadRequest(create_review(request), b"Invalid JSON")
 
     def test_missing_title(self):
@@ -320,9 +323,9 @@ class UpdateReviewTest(TestCase):
             return False
         return True
 
-    def check_post(self, post, response_check, ajax=False, compare={}, content=None):
+    def check_post(self, post, response_check, ajax=False, compare={}, content=None):  # noqa 501
         if compare:
-            response_check(self.post(post, ajax=ajax), compare=compare, content=content)
+            response_check(self.post(post, ajax=ajax), compare=compare, content=content)  # noqa 501
         else:
             response_check(self.post(post, ajax=ajax), content=content)
 
@@ -331,7 +334,10 @@ class UpdateReviewTest(TestCase):
             "HTTP_X_REQUESTED_WITH": "XMLHttpRequest",
             "content_type": "application/json",
         }
-        request = self.factory.post(reverse("update_review"), "invalid:json}", **kwargs)
+        request = self.factory.post(
+            reverse("update_review"),
+            "invalid:json}",
+            **kwargs)
         self.assertBadRequest(update_review(request), b"Invalid JSON")
 
     # Test with token id that exists
@@ -444,7 +450,7 @@ class ContinueReviewTest(TestCase):
 
     def post(self, post):
         kwargs = {"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"}
-        request = self.factory.post(reverse("continue_review"), post, **kwargs)
+        request = self.factory.post(reverse("continue_review"), post, **kwargs)  # noqa 501
         return continue_review(request)
 
     def test_non_existent_pass_code(self):

--- a/crtool/tests/test_views.py
+++ b/crtool/tests/test_views.py
@@ -350,15 +350,7 @@ class UpdateReviewTest(TestCase):
             "curriculumTitle": "Updated title",
             "publicationDate": ""
         }
-        compare = {
-            "id": "242449c9251243c1b512d2",
-            "pass_code": None,
-            "gradeRange": "Middle school",
-            "last_updated": "2020-07-12 04:52:56.858970+00:00",
-            "curriculumTitle": "Updated title",
-            "publicationDate": ""
-        }
-        self.check_post(post, self.assertUpdateSuccess, compare=compare)
+        self.check_post(post, self.assertUpdateSuccess, compare=post)
 
     # Test with token id that doesn't exist
     def test_non_existent_id(self):
@@ -427,8 +419,11 @@ class UpdateReviewTest(TestCase):
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",
             "publicationDate": "",
-            "junk": "0123456789" * 60000,
+            "junk": "0123456789" * 49000,
         }
+        self.check_post(post, self.assertUpdateSuccess, compare=post)
+
+        post["junk"] = "0123456789" * 50000
         self.check_post(post, self.assertBadRequest, content=b"Too Large")
 
     # Test empty post

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -11,7 +11,15 @@ from crtool.models import CurriculumReviewSession
 
 def create_review(request):
     if request.method == 'POST':
-        fd = json.loads(request.body.decode("utf-8"))
+        body_str = request.body.decode("utf-8")
+        # Allow 200 for title, 50 for date, and 30 for JSON wrapper
+        if len(body_str) > (200 + 50 + 30):
+            return HttpResponse(status=400)
+
+        try:
+            fd = json.loads(body_str)
+        except:
+            return HttpResponse(status=400)
 
         title = fd['tdp-crt_title'] if 'tdp-crt_title' in fd else ''
         pub_date = fd['tdp-crt_pubdate'] if 'tdp-crt_pubdate' in fd else ''
@@ -83,7 +91,17 @@ def continue_review(request):
 
 def update_review(request):
     if request.method == 'POST':
-        data = json.loads(request.body.decode("utf-8"))
+        body_str = request.body.decode("utf-8")
+        # Pasting in tons of lorem ipsum content (1,280 words 8,660 characters) everywhere
+        # brought total body bytes to 295360, so this is more than generous.
+        if len(body_str) > 500000:
+            return HttpResponse(status=400)
+
+        try:
+            data = json.loads(body_str)
+        except:
+            return HttpResponse(status=400)
+
         if "id" in data:
             try:
                 review = CurriculumReviewSession.objects.get(id=data["id"])

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -14,12 +14,12 @@ def create_review(request):
         body_str = request.body.decode("utf-8")
         # Allow 200 for title, 50 for date, and 30 for JSON wrapper
         if len(body_str) > (200 + 50 + 30):
-            return HttpResponse(status=400)
+            return HttpResponse(content="Too Large", status=400)
 
         try:
             fd = json.loads(body_str)
         except:
-            return HttpResponse(status=400)
+            return HttpResponse(content="Invalid JSON", status=400)
 
         title = fd['tdp-crt_title'] if 'tdp-crt_title' in fd else ''
         pub_date = fd['tdp-crt_pubdate'] if 'tdp-crt_pubdate' in fd else ''
@@ -95,12 +95,12 @@ def update_review(request):
         # Pasting in tons of lorem ipsum content (1,280 words 8,660 characters) everywhere
         # brought total body bytes to 295360, so this is more than generous.
         if len(body_str) > 500000:
-            return HttpResponse(status=400)
+            return HttpResponse(content="Too Large", status=400)
 
         try:
             data = json.loads(body_str)
         except:
-            return HttpResponse(status=400)
+            return HttpResponse(content="Invalid JSON", status=400)
 
         if "id" in data:
             try:

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -1,6 +1,7 @@
 import json
 import time
 from datetime import datetime
+from json.decoder import JSONDecodeError
 
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
@@ -18,7 +19,7 @@ def create_review(request):
 
         try:
             fd = json.loads(body_str)
-        except:
+        except JSONDecodeError:
             return HttpResponse(content="Invalid JSON", status=400)
 
         title = fd['tdp-crt_title'] if 'tdp-crt_title' in fd else ''
@@ -92,14 +93,15 @@ def continue_review(request):
 def update_review(request):
     if request.method == 'POST':
         body_str = request.body.decode("utf-8")
-        # Pasting in tons of lorem ipsum content (1,280 words 8,660 characters) everywhere
-        # brought total body bytes to 295360, so this is more than generous.
+        # Pasting in tons of lorem ipsum content (1,280 words 8,660
+        # characters) everywhere brought total body bytes to 295360,
+        # so this is more than generous.
         if len(body_str) > 500000:
             return HttpResponse(content="Too Large", status=400)
 
         try:
             data = json.loads(body_str)
-        except:
+        except JSONDecodeError:
             return HttpResponse(content="Invalid JSON", status=400)
 
         if "id" in data:


### PR DESCRIPTION
Limits the acceptable size of review entry and formally catches JSONDecodeError instead of litting Django deal with it.

---

## Additions

- Returns 400 status if request body limit too large
- Returns 400 status if request body is invalid JSON
- Adds unit tests for those

## How to test this PR

Run unit tests.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated
