### PR TITLE
Limit title to 150 chars

### DIFF
--- a/crtool/jinja2/crtool/crt-start.html
+++ b/crtool/jinja2/crtool/crt-start.html
@@ -162,7 +162,7 @@
                         <input class="a-text-input
                                     a-text-input__full"
                             type="text"
-                            maxlength="200"
+                            maxlength="150"
                             id="tdp-crt_title"
                             name="tdp-crt_title">
                     </div>

--- a/crtool/tests/test_views.py
+++ b/crtool/tests/test_views.py
@@ -61,7 +61,6 @@ class CreateReviewTest(TestCase):
         post = {
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest)
 
@@ -70,7 +69,6 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "",
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest)
 
@@ -79,7 +77,6 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "Test title" * 100,
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest, content=b"Too Large")
 
@@ -87,7 +84,6 @@ class CreateReviewTest(TestCase):
         post = {
             "tdp-crt_title": "Test title",
             "tdp-crt_pubdate": "Jan 1, 2001",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest)
 
@@ -96,7 +92,6 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "Test title",
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest)
 
@@ -105,13 +100,12 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "Test title",
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         compare = {
             "curriculumTitle": "Test title",
             "publicationDate": "Jan 1, 2001",
             "gradeRange": "Elementary school",
-            "pass_code": "P455W0RD",
+            "pass_code": "",
         }
         self.check_post(post, self.assertCreateSuccess, compare=compare)
 
@@ -133,7 +127,6 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "Test title",
             "tdp-crt_grade": "Elementary school",
             "tdp-crt_pubdate": "",
-            "tdp-crt_pass_code": "",
         }
         compare = {
             "curriculumTitle": "Test title",
@@ -147,7 +140,6 @@ class CreateReviewTest(TestCase):
         post = {
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest, ajax=True)
 
@@ -156,7 +148,6 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "",
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest, ajax=True)
 
@@ -164,7 +155,6 @@ class CreateReviewTest(TestCase):
         post = {
             "tdp-crt_title": "Test title",
             "tdp-crt_pubdate": "Jan 1, 2001",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest, ajax=True)
 
@@ -173,7 +163,6 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "Test title",
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "",
-            "tdp-crt_pass_code": "P455W0RD",
         }
         self.check_post(post, self.assertBadRequest, ajax=True)
 
@@ -182,14 +171,13 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "Test title",
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
-            "tdp-crt_pass_code": "P455W0RD",
         }
 
         compare = {
             "curriculumTitle": "Test title",
             "publicationDate": "Jan 1, 2001",
             "gradeRange": "Elementary school",
-            "pass_code": "P455W0RD",
+            "pass_code": "",
         }
         self.check_post(
             post, self.assertCreateSuccess, ajax=True, compare=compare
@@ -215,7 +203,6 @@ class CreateReviewTest(TestCase):
             "tdp-crt_title": "Test title",
             "tdp-crt_grade": "Elementary school",
             "tdp-crt_pubdate": "",
-            "tdp-crt_pass_code": "",
         }
         compare = {
             "curriculumTitle": "Test title",
@@ -361,7 +348,7 @@ class UpdateReviewTest(TestCase):
     def test_update_title(self):
         post = {
             "id": "242449c9251243c1b512d2",
-            "pass_code": None,
+            "pass_code": "",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",
@@ -373,7 +360,7 @@ class UpdateReviewTest(TestCase):
     def test_non_existent_id(self):
         post = {
             "id": "6893d3af8eb54e74a27883",
-            "pass_code": None,
+            "pass_code": "",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",
@@ -384,8 +371,8 @@ class UpdateReviewTest(TestCase):
     # Test with null token id
     def test_null_id(self):
         post = {
-            "id": None,
-            "pass_code": None,
+            "id": "",
+            "pass_code": "",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",
@@ -396,7 +383,7 @@ class UpdateReviewTest(TestCase):
     # Test with missing token id
     def test_missing_id(self):
         post = {
-            "pass_code": None,
+            "pass_code": "",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",
@@ -408,7 +395,7 @@ class UpdateReviewTest(TestCase):
     def test_empty_id(self):
         post = {
             "id": "",
-            "pass_code": None,
+            "pass_code": "",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",
@@ -420,7 +407,7 @@ class UpdateReviewTest(TestCase):
     def test_invalid_id(self):
         post = {
             "id": "apple",
-            "pass_code": None,
+            "pass_code": "",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",
@@ -431,7 +418,7 @@ class UpdateReviewTest(TestCase):
     def test_overly_large_body(self):
         post = {
             "id": "242449c9251243c1b512d2",
-            "pass_code": None,
+            "pass_code": "",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "Updated title",

--- a/crtool/tests/test_views.py
+++ b/crtool/tests/test_views.py
@@ -62,7 +62,7 @@ class CreateReviewTest(TestCase):
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
         }
-        self.check_post(post, self.assertBadRequest)
+        self.check_post(post, self.assertBadRequest, content=b"Invalid Input")
 
     def test_empty_title(self):
         post = {
@@ -72,13 +72,13 @@ class CreateReviewTest(TestCase):
         }
         self.check_post(post, self.assertBadRequest)
 
-    def test_long_title(self):
+    def test_title_not_string(self):
         post = {
-            "tdp-crt_title": "Test title" * 100,
+            "tdp-crt_title": ["Hello", "World"],
             "tdp-crt_pubdate": "Jan 1, 2001",
             "tdp-crt_grade": "Elementary school",
         }
-        self.check_post(post, self.assertBadRequest, content=b"Too Large")
+        self.check_post(post, self.assertBadRequest, content=b"Invalid Input")
 
     def test_missing_grade_level(self):
         post = {
@@ -105,22 +105,31 @@ class CreateReviewTest(TestCase):
             "curriculumTitle": "Test title",
             "publicationDate": "Jan 1, 2001",
             "gradeRange": "Elementary school",
-            "pass_code": "",
         }
         self.check_post(post, self.assertCreateSuccess, compare=compare)
 
-    def test_missing_pubdate_and_passcode(self):
+    def test_appropriate_title(self):
+        post = {
+            "tdp-crt_title": "T" * 150,
+            "tdp-crt_pubdate": "Jan 1, 2001",
+            "tdp-crt_grade": "Elementary school",
+        }
+        self.check_post(post, self.assertCreateSuccess)
+
+    def test_title_too_long(self):
+        post = {
+            "tdp-crt_title": "T" * 151,
+            "tdp-crt_pubdate": "Jan 1, 2001",
+            "tdp-crt_grade": "Elementary school",
+        }
+        self.check_post(post, self.assertBadRequest, content=b"Too Large")
+
+    def test_missing_pubdate(self):
         post = {
             "tdp-crt_title": "Test title",
             "tdp-crt_grade": "Elementary school",
         }
-        compare = {
-            "curriculumTitle": "Test title",
-            "gradeRange": "Elementary school",
-            "publicationDate": "",
-            "pass_code": "",
-        }
-        self.check_post(post, self.assertCreateSuccess, compare=compare)
+        self.check_post(post, self.assertBadRequest, content=b"Invalid Input")
 
     def test_empty_pubdate_and_passcode(self):
         post = {
@@ -183,19 +192,13 @@ class CreateReviewTest(TestCase):
             post, self.assertCreateSuccess, ajax=True, compare=compare
         )  # noqa 501
 
-    def test_missing_pubdate_and_passcode_ajax(self):
+    def test_missing_pubdate_ajax(self):
         post = {
             "tdp-crt_title": "Test title",
             "tdp-crt_grade": "Elementary school",
         }
-        compare = {
-            "curriculumTitle": "Test title",
-            "gradeRange": "Elementary school",
-            "publicationDate": "",
-            "pass_code": "",
-        }
         self.check_post(
-            post, self.assertCreateSuccess, compare=compare, ajax=True
+            post, self.assertBadRequest, ajax=True, content=b"Invalid Input"
         )  # noqa 501
 
     def test_empty_pubdate_and_passcode_ajax(self):

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -11,117 +11,128 @@ from crtool.models import CurriculumReviewSession
 
 
 def create_review(request):
-    if request.method == "POST":
-        body_str = request.body.decode("utf-8")
-        # Allow 200 for title, 50 for date, and 30 for JSON wrapper
-        if len(body_str) > (200 + 50 + 30):
-            return HttpResponse(content="Too Large", status=400)
+    if request.method != "POST":
+        return HttpResponse(status=400)
 
-        try:
-            fd = json.loads(body_str)
-        except JSONDecodeError:
-            return HttpResponse(content="Invalid JSON", status=400)
+    body_str = request.body.decode("utf-8")
+    # Allow 200 for title, 50 for date, and 30 for JSON wrapper
+    if len(body_str) > (200 + 50 + 30):
+        return HttpResponse(content="Too Large", status=400)
 
-        title = fd["tdp-crt_title"] if "tdp-crt_title" in fd else ""
-        pub_date = fd["tdp-crt_pubdate"] if "tdp-crt_pubdate" in fd else ""
-        grade_range = fd["tdp-crt_grade"] if "tdp-crt_grade" in fd else ""
-        pass_code = (
-            fd["tdp-crt_pass_code"] if "tdp-crt_pass_code" in fd else ""
-        )
-        review_id = CurriculumReviewSession.id_generator()
-        last_updated = timezone.now()
+    try:
+        fd = json.loads(body_str)
+    except JSONDecodeError:
+        return HttpResponse(content="Invalid JSON", status=400)
 
-        if not title or not grade_range:
-            return HttpResponse(status=400)
-        data = {
-            "id": str(review_id),
-            "pass_code": pass_code,
-            "last_updated": str(datetime.isoformat(last_updated)),
-            "curriculumTitle": title,
-            "publicationDate": pub_date,
-            "gradeRange": grade_range,
-        }
+    title = fd["tdp-crt_title"] if "tdp-crt_title" in fd else ""
+    pub_date = fd["tdp-crt_pubdate"] if "tdp-crt_pubdate" in fd else ""
+    grade_range = fd["tdp-crt_grade"] if "tdp-crt_grade" in fd else ""
+    pass_code = (
+        fd["tdp-crt_pass_code"] if "tdp-crt_pass_code" in fd else ""
+    )
+    review_id = CurriculumReviewSession.id_generator()
+    last_updated = timezone.now()
 
-        review = CurriculumReviewSession.objects.create(
-            id=review_id,
-            pass_code=pass_code,
-            last_updated=last_updated,
-            data=data,
-        )
+    if not title or not grade_range:
+        return HttpResponse(status=400)
 
-        if review:
-            return JsonResponse(review.data)
+    data = {
+        "id": str(review_id),
+        "pass_code": pass_code,
+        "last_updated": str(datetime.isoformat(last_updated)),
+        "curriculumTitle": title,
+        "publicationDate": pub_date,
+        "gradeRange": grade_range,
+    }
 
-    return HttpResponse(status=400)
+    review = CurriculumReviewSession.objects.create(
+        id=review_id,
+        pass_code=pass_code,
+        last_updated=last_updated,
+        data=data,
+    )
+
+    if review:
+        return JsonResponse(review.data)
+    else:
+        return HttpResponse(status=400)
 
 
 def get_review(request):
-    data = {}
-    if request.method == "POST":
-        review_id = request.POST.get("token")
-        try:
-            review = CurriculumReviewSession.objects.get(id=review_id)
-            if review:
-                data = review.data
-        except (
-            CurriculumReviewSession.DoesNotExist,
-            ValueError,
-            ValidationError,
-        ):
-            return HttpResponse(status=404)
-        return JsonResponse(data)
-    return HttpResponse(status=404)
+    if request.method != "POST":
+        return HttpResponse(status=404)
+
+    review_id = request.POST.get("token")
+    try:
+        review = CurriculumReviewSession.objects.get(id=review_id)
+        if not review:
+            return JsonResponse({})
+
+        return JsonResponse(review.data)
+    except (
+        CurriculumReviewSession.DoesNotExist,
+        ValueError,
+        ValidationError,
+    ):
+        return HttpResponse(status=404)
 
 
 def continue_review(request):
-    if request.method == "POST":
-        review_id = request.POST.get("access_code")
-        # Critical pause to prevent brute-forcing the shorter pass_code values
-        time.sleep(1)
-        try:
-            review = CurriculumReviewSession.objects.get(id=review_id)
-            if review:
-                return HttpResponseRedirect("../tool/#id=" + review.id)
-        except (
-            CurriculumReviewSession.DoesNotExist,
-            ValueError,
-            ValidationError,
-        ):
+    if request.method != "POST":
+        return HttpResponse(status=404)
+
+    review_id = request.POST.get("access_code")
+    # Critical pause to prevent brute-forcing the shorter pass_code values
+    time.sleep(1)
+    try:
+        review = CurriculumReviewSession.objects.get(id=review_id)
+        if not review:
             return HttpResponse(status=404)
-    return HttpResponse(status=404)
+
+        return HttpResponseRedirect("../tool/#id=" + review.id)
+    except (
+        CurriculumReviewSession.DoesNotExist,
+        ValueError,
+        ValidationError,
+    ):
+        return HttpResponse(status=404)
 
 
 def update_review(request):
-    if request.method == "POST":
-        body_str = request.body.decode("utf-8")
-        # Pasting in tons of lorem ipsum content (1,280 words 8,660
-        # characters) everywhere brought total body bytes to 295360,
-        # so this is more than generous.
-        if len(body_str) > 500000:
-            return HttpResponse(content="Too Large", status=400)
+    if request.method != "POST":
+        return HttpResponse(status=404)
 
-        try:
-            data = json.loads(body_str)
-        except JSONDecodeError:
-            return HttpResponse(content="Invalid JSON", status=400)
+    body_str = request.body.decode("utf-8")
+    # Pasting in tons of lorem ipsum content (1,280 words 8,660
+    # characters) everywhere brought total body bytes to 295360,
+    # so this is more than generous.
+    if len(body_str) > 500000:
+        return HttpResponse(content="Too Large", status=400)
 
-        if "id" in data:
-            try:
-                review = CurriculumReviewSession.objects.get(id=data["id"])
-                if review:
-                    # Update last_updated date
-                    last_updated = timezone.now()
-                    iso_last_updated = str(datetime.isoformat(last_updated))
-                    data["last_updated"] = iso_last_updated
-                    review.data = data
-                    review.last_updated = last_updated
-                    review.save()
-                    return JsonResponse(review.data)
-            except (
-                CurriculumReviewSession.DoesNotExist,
-                ValueError,
-                ValidationError,
-            ):
-                return HttpResponse(status=404)
+    try:
+        data = json.loads(body_str)
+    except JSONDecodeError:
+        return HttpResponse(content="Invalid JSON", status=400)
 
-    return HttpResponse(status=404)
+    if "id" not in data:
+        return HttpResponse(status=404)
+
+    try:
+        review = CurriculumReviewSession.objects.get(id=data["id"])
+        if not review:
+            return HttpResponse(status=404)
+
+        # Update last_updated date
+        last_updated = timezone.now()
+        iso_last_updated = str(datetime.isoformat(last_updated))
+        data["last_updated"] = iso_last_updated
+        review.data = data
+        review.last_updated = last_updated
+        review.save()
+        return JsonResponse(review.data)
+    except (
+        CurriculumReviewSession.DoesNotExist,
+        ValueError,
+        ValidationError,
+    ):
+        return HttpResponse(status=404)

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -27,18 +27,16 @@ def create_review(request):
     title = fd["tdp-crt_title"] if "tdp-crt_title" in fd else ""
     pub_date = fd["tdp-crt_pubdate"] if "tdp-crt_pubdate" in fd else ""
     grade_range = fd["tdp-crt_grade"] if "tdp-crt_grade" in fd else ""
-    pass_code = (
-        fd["tdp-crt_pass_code"] if "tdp-crt_pass_code" in fd else ""
-    )
     review_id = CurriculumReviewSession.id_generator()
     last_updated = timezone.now()
 
     if not title or not grade_range:
         return HttpResponse(status=400)
 
+    # pass_code is a legacy value no longer used.
     data = {
         "id": str(review_id),
-        "pass_code": pass_code,
+        "pass_code": "",
         "last_updated": str(datetime.isoformat(last_updated)),
         "curriculumTitle": title,
         "publicationDate": pub_date,
@@ -47,7 +45,7 @@ def create_review(request):
 
     review = CurriculumReviewSession.objects.create(
         id=review_id,
-        pass_code=pass_code,
+        pass_code="",
         last_updated=last_updated,
         data=data,
     )
@@ -82,7 +80,7 @@ def continue_review(request):
         return HttpResponse(status=404)
 
     review_id = request.POST.get("access_code")
-    # Critical pause to prevent brute-forcing the shorter pass_code values
+    # Critical pause to prevent brute-forcing review_id's
     time.sleep(1)
     try:
         review = CurriculumReviewSession.objects.get(id=review_id)


### PR DESCRIPTION
Limits title input to 150 chars and pub date to 50, and validates input type as well.

## Changes

- Validate title and pub_date string len directly instead of the combined JSON input size.
- Refactors views to use return-early for easier reading.
- Eliminates pass_code input handling as this is no longer used.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
