### PR TITLE
Switch to layout-2-1.html base-template

### DIFF
--- a/crtool/jinja2/crtool/crt-start.html
+++ b/crtool/jinja2/crtool/crt-start.html
@@ -1,4 +1,4 @@
-{% extends 'layout-2-1-bleedbar.html' %}
+{% extends 'layout-2-1.html' %}
 
 
 {# HEAD items #}


### PR DESCRIPTION
This replicates the functionality of layout-2-1-bleedbar.html after cfpb/consumerfinance.gov/pull/7164 (and layout-2-1-bleedbar.html is being removed).